### PR TITLE
For rule core-006 the use of COPY is generally preferred

### DIFF
--- a/dockerfile_sec/rules/core.yaml
+++ b/dockerfile_sec/rules/core.yaml
@@ -19,8 +19,8 @@
   reference: https://snyk.io/blog/10-docker-image-security-best-practices/
   severity: Medium
 - id: core-006
-  description: Use of COPY instead of ADD
-  regex: '(COPY.)'
+  description: Use of ADD instead of COPY
+  regex: '(ADD.)'
   reference: https://snyk.io/blog/10-docker-image-security-best-practices/
   severity: Low
 - id: core-007


### PR DESCRIPTION
For rule core-006 the use of COPY is generally preferred, however the current rule reflects the inverse.

Additional reference:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/